### PR TITLE
Improve link generation behavior.

### DIFF
--- a/tests/test_git.lua
+++ b/tests/test_git.lua
@@ -64,9 +64,17 @@ TestGit = {}
 
   function TestGit:test_get_branch_or_commit()
     self.active_branch_or_commit = self.branch
-    lu.assertEquals(git.get_branch_or_commit(), self.branch)
+
+    local result = git.get_branch_or_commit()
+    lu.assertEquals(result.name, self.branch)
+    lu.assertEquals(result.type, "branch")
+
     self.active_branch_or_commit = self.commit
-    lu.assertEquals(git.get_branch_or_commit(), self.commit)
+
+    local result = git.get_branch_or_commit()
+    lu.assertEquals(result.name, self.commit)
+    lu.assertEquals(result.type, "commit")
+
   end
 
 


### PR DESCRIPTION
## Summary of changes
Now when we retrieve the branch/commit name, we also know which is which. i.e. if it's a branch or commit. It is very difficult to check if a commit is available on the remote repo, so we don't bother, but, if it is a branch, we will at least check that it exists in the remote before generating a link and show an error message to the user if not