### PR TITLE
Add support for gitlab self host options

### DIFF
--- a/lua/gitportal/git.lua
+++ b/lua/gitportal/git.lua
@@ -114,7 +114,7 @@ local function get_base_git_host_url()
 end
 
 function M.assemble_permalink(remote_url, branch_or_commit, git_path, git_host)
-    if git_host.name == GIT_HOSTS.github.name then
+    if git_host == GIT_HOSTS.github.name then
         return remote_url .. "/blob/" .. branch_or_commit .. "/" .. git_path
     elseif git_host == GIT_HOSTS.gitlab.name then
         return remote_url .. "/-/blob/" .. branch_or_commit .. "/" .. git_path

--- a/lua/gitportal/git.lua
+++ b/lua/gitportal/git.lua
@@ -3,6 +3,9 @@ local config = require("gitportal.config")
 local nv_utils = require("gitportal.nv_utils")
 
 local git_root_patterns = { ".git" }
+-- GIT HOSTS
+local github = "github"
+local gitlab = "gitlab"
 
 local M = {}
 
@@ -24,10 +27,10 @@ function M.determine_git_host()
     local origin_url = M.get_origin_url()
     if origin_url == nil then
         return nil
-    elseif string.find(origin_url, "github", 0, true) then
-        return "github"
-    elseif string.find(origin_url, "gitlab", 0, true) then
-        return "gitlab"
+    elseif string.find(origin_url, github, 0, true) then
+        return github
+    elseif string.find(origin_url, gitlab, 0, true) then
+        return gitlab
     else
         return nil
     end
@@ -82,7 +85,7 @@ function M.get_branch_or_commit()
     }
 end
 
-local function get_base_github_url()
+local function get_base_git_host_url()
     -- Get the base github url for a repo...
     -- Ex: https://github.com/trevorhauter/gitportal.nvim
     local origin_url = M.get_origin_url()
@@ -98,9 +101,9 @@ local function get_base_github_url()
 end
 
 function M.assemble_permalink(remote_url, branch_or_commit, git_path, git_host)
-    if git_host == "github" then
+    if git_host == github then
         return remote_url .. "/blob/" .. branch_or_commit .. "/" .. git_path
-    elseif git_host == "gitlab" then
+    elseif git_host == gitlab then
         return remote_url .. "/-/blob/" .. branch_or_commit .. "/" .. git_path
     else
         return nil
@@ -112,9 +115,9 @@ function M.create_url_params(start_line, end_line, githost)
     -- if applicable
     local first_prefix, second_prefix
     first_prefix = "#L"
-    if githost == "github" then
+    if githost == github then
         second_prefix = "-L"
-    elseif githost == "gitlab" then
+    elseif githost == gitlab then
         second_prefix = "-"
     end
 
@@ -170,7 +173,7 @@ function M.get_git_url_for_current_file()
         return nil
     end
 
-    local remote_url = get_base_github_url()
+    local remote_url = get_base_git_host_url()
     local branch_or_commit = M.get_branch_or_commit()
     local git_path = M.get_git_file_path()
     local git_host = M.determine_git_host()

--- a/lua/gitportal/git.lua
+++ b/lua/gitportal/git.lua
@@ -249,6 +249,8 @@ function M.open_file_from_git_url(parsed_url)
             nv_utils.highlight_line_range_for_new_buffer(parsed_url.start_line, parsed_url.end_line)
             nv_utils.open_file(absolute_file_path)
         end
+    else
+        nv_utils.open_file(absolute_file_path)
     end
 end
 

--- a/lua/gitportal/git.lua
+++ b/lua/gitportal/git.lua
@@ -144,10 +144,13 @@ function M.get_git_url_for_current_file()
         return nil
     end
 
+    -- TODO: Add a func here to determine which host we are generating a link for
+    -- TODO: Add branching logic to create different formats for different hosts (gitlab)
     local permalink = remote_url .. "/blob/" .. branch_or_commit.name .. "/" .. git_path
 
     if vim.fn.mode() ~= "n" or config.options.always_include_current_line == true then
         local start_line, end_line = nv_utils.get_visual_selection_lines()
+        -- TODO: Allow url_params to accept an argument to determine format of start/end line
         permalink = permalink .. M.create_url_params(start_line, end_line)
     end
 

--- a/lua/gitportal/git.lua
+++ b/lua/gitportal/git.lua
@@ -181,6 +181,7 @@ function M.get_git_url_for_current_file()
     end
     if git_host == nil then
         cli.log_error("Couldn't determine git host!")
+        return nil
     end
 
     local permalink = M.assemble_permalink(remote_url, branch_or_commit.name, git_path, git_host)

--- a/lua/gitportal/url_utils.lua
+++ b/lua/gitportal/url_utils.lua
@@ -67,7 +67,8 @@ end
 local function parse_gitlab_url(url)
     -- a GitLab url may appear as follows... (Check tests for more variants)
     -- https://gitlab.com/gitportal/gitlab-test/-/blob/master/public/index.html?ref_type=heads#L5-11
-    local repo, remainder = url:match("gitlab.com/[^/]+/([^/]+)/%-?/?blob/(.+)")
+    local repo, remainder = url:match("/.+/([^/]+)/%-/blob/(.+)")
+    print(repo, remainder)
     local branch_or_commit, file_path = parse_url_remainder(remainder)
 
     return repo, branch_or_commit, file_path

--- a/lua/gitportal/url_utils.lua
+++ b/lua/gitportal/url_utils.lua
@@ -68,7 +68,6 @@ local function parse_gitlab_url(url)
     -- a GitLab url may appear as follows... (Check tests for more variants)
     -- https://gitlab.com/gitportal/gitlab-test/-/blob/master/public/index.html?ref_type=heads#L5-11
     local repo, remainder = url:match("/.+/([^/]+)/%-/blob/(.+)")
-    print(repo, remainder)
     local branch_or_commit, file_path = parse_url_remainder(remainder)
 
     return repo, branch_or_commit, file_path

--- a/tests/test_url_utils.lua
+++ b/tests/test_url_utils.lua
@@ -152,23 +152,6 @@ function TestParseGitHostUrl:test_gitlab_url_with_query_param()
     test_github_url(base_url, expected_result, gitlab_single_line_info, gitlab_line_range_info)
 end
 
--- TODO: Remove this after adding proper support for gitlab url generation
---function TestParseGitHostUrl:test_gitlab_url_with_github_format()
---So this is more of a feature than a bug but at the moment we are generating links in only one format.
---Funnily enough, gitlab doesn't really seem to care about that. But we need to make sure we can ingest these
---Types of links too. I will probably have to resolve this at a later date... #TODO
---local base_url =
---"https://gitlab.com/gitportal/gitlab-test/blob/7e14d7545918b9167dd65bea8da454d2e389df5b/.gitlab-ci.yml"
---local expected_result = {
---repo = "gitlab-test",
---branch_or_commit = "7e14d7545918b9167dd65bea8da454d2e389df5b",
---file_path = ".gitlab-ci.yml",
---start_line = nil,
---end_line = nil,
---}
---test_github_url(base_url, expected_result, github_single_line_info, github_line_range_info)
---end
-
 function TestParseGitHostUrl:test_self_host_gitlab_url()
     local base_url =
         "https://gitlab-ee.agil.company.com.ar/orgname/frontend/app-shell/-/blob/feature/mfError/src/hooks/useSessionTimer.js?ref_type=heads"

--- a/tests/test_url_utils.lua
+++ b/tests/test_url_utils.lua
@@ -45,7 +45,7 @@ function TestParseGitHostUrl:setUp()
     ---@diagnostic disable-next-line: duplicate-set-field
     git_helper.branch_or_commit_exists = function(param)
         -- Hard coded branch values
-        if param == "main" or param == "master" or param == "githost/gitlab" then
+        if param == "main" or param == "master" or param == "githost/gitlab" or param == "feature/mfError" then
             return "asdfjkl;asdfjkl;" -- We just check if the return is truthy
         end
 
@@ -152,20 +152,34 @@ function TestParseGitHostUrl:test_gitlab_url_with_query_param()
     test_github_url(base_url, expected_result, gitlab_single_line_info, gitlab_line_range_info)
 end
 
-function TestParseGitHostUrl:test_gitlab_url_with_github_format()
-    -- So this is more of a feature than a bug but at the moment we are generating links in only one format.
-    -- Funnily enough, gitlab doesn't really seem to care about that. But we need to make sure we can ingest these
-    -- Types of links too. I will probably have to resolve this at a later date... #TODO
+-- TODO: Remove this after adding proper support for gitlab url generation
+--function TestParseGitHostUrl:test_gitlab_url_with_github_format()
+--So this is more of a feature than a bug but at the moment we are generating links in only one format.
+--Funnily enough, gitlab doesn't really seem to care about that. But we need to make sure we can ingest these
+--Types of links too. I will probably have to resolve this at a later date... #TODO
+--local base_url =
+--"https://gitlab.com/gitportal/gitlab-test/blob/7e14d7545918b9167dd65bea8da454d2e389df5b/.gitlab-ci.yml"
+--local expected_result = {
+--repo = "gitlab-test",
+--branch_or_commit = "7e14d7545918b9167dd65bea8da454d2e389df5b",
+--file_path = ".gitlab-ci.yml",
+--start_line = nil,
+--end_line = nil,
+--}
+--test_github_url(base_url, expected_result, github_single_line_info, github_line_range_info)
+--end
+
+function TestParseGitHostUrl:test_self_host_gitlab_url()
     local base_url =
-        "https://gitlab.com/gitportal/gitlab-test/blob/7e14d7545918b9167dd65bea8da454d2e389df5b/.gitlab-ci.yml"
+        "https://gitlab-ee.agil.company.com.ar/orgname/frontend/app-shell/-/blob/feature/mfError/src/hooks/useSessionTimer.js?ref_type=heads"
     local expected_result = {
-        repo = "gitlab-test",
-        branch_or_commit = "7e14d7545918b9167dd65bea8da454d2e389df5b",
-        file_path = ".gitlab-ci.yml",
+        repo = "app-shell",
+        branch_or_commit = "feature/mfError",
+        file_path = "src/hooks/useSessionTimer.js",
         start_line = nil,
         end_line = nil,
     }
-    test_github_url(base_url, expected_result, github_single_line_info, github_line_range_info)
+    test_github_url(base_url, expected_result, gitlab_single_line_info, gitlab_line_range_info)
 end
 
 -- ****


### PR DESCRIPTION
Complete:
- Added support for self host options in url parsing

Left to do:
- Update url generation to be smarter and adhere to each githosts formats. This simplifies url parsing and is technical debt we need to pay anyways.