### PR TITLE
Fix bug in originl url parsing

### DIFF
--- a/lua/gitportal/git.lua
+++ b/lua/gitportal/git.lua
@@ -98,8 +98,10 @@ function M.get_branch_or_commit()
 end
 
 function M.parse_origin_url(origin_url)
+    -- remove any trailing spaces or line breaks from the end of the line
+    origin_url = origin_url:gsub("%s$", "")
     -- Trim any appending .git from the url, including new line
-    origin_url = origin_url:gsub("%.git%s*$", "")
+    origin_url = origin_url:gsub("%.git$", "")
 
     local temp_url = origin_url
     -- For any of the non-self-hosted git hosts, trim here

--- a/tests/test_git_remote_urls.lua
+++ b/tests/test_git_remote_urls.lua
@@ -26,6 +26,13 @@ function TestParseOriginUrl:test_regular_github_http_origin_url()
     validate_parsed_url(origin_url, expected_result)
 end
 
+function TestParseOriginUrl:test_github_http_origin_url_not_git()
+    -- A url that doesn't have the usual appending .git
+    local origin_url = "https://github.com/docker/welcome-to-docker"
+    local expected_result = "https://github.com/docker/welcome-to-docker"
+    validate_parsed_url(origin_url, expected_result)
+end
+
 function TestParseOriginUrl:test_regular_gitlab_http_origin_url()
     local origin_url = "https://gitlab.com/gitportal/gitlab-test.git"
     local expected_result = "https://gitlab.com/gitportal/gitlab-test"


### PR DESCRIPTION
Noticed this in the welcome to docker repo. There was no appending `.git`, so the new line character at the end was never trimmed. 