### PR TITLE
Add support for onedev

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,10 +47,9 @@ jobs:
       # Step 4: Set LUA_PATH and LUA_CPATH for LuaUnit and run tests
       - name: Run tests
         run: |
-          export LUA_PATH="$HOME/.luarocks/share/lua/5.1/?.lua;$HOME/.luarocks/share/lua/5.1/?/init.lua;$GITHUB_WORKSPACE/?.lua;$LUA_PATH"
+          export LUA_PATH="$HOME/.luarocks/share/lua/5.1/?.lua;$HOME/.luarocks/share/lua/5.1/?/init.lua;$GITHUB_WORKSPACE/?.lua;$GITHUB_WORKSPACE/?/init.lua;$LUA_PATH"
           export LUA_CPATH="$HOME/.luarocks/lib/lua/5.1/?.so;$LUA_CPATH"
           echo "LUA_PATH: $LUA_PATH"
           echo "LUA_CPATH: $LUA_CPATH"
-          pwd
           lua ./tests/run_tests.lua  # Adjust the path to your test file
 

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ The following command is created upon setup that takes several arguments.
 ## ꩜ Supported git web hosts
 Git host                        | Supported          | Self host support 
 --------------------------------|--------------------|---------------------------
-[GitHub](https://github.com/)   | :white_check_mark: | :x: Please open issue for support
+[GitHub](https://github.com/)   | :white_check_mark: | :white_check_mark:
 [GitLab](https://gitlab.com/)   | :white_check_mark: | :white_check_mark:
 [Forgejo](https://forgejo.org/) | N/A     | :white_check_mark:
 

--- a/README.md
+++ b/README.md
@@ -120,9 +120,10 @@ The following command is created upon setup that takes several arguments.
 ## ꩜ Supported git web hosts
 Git host                        | Supported          | Self host support 
 --------------------------------|--------------------|---------------------------
+[Forgejo](https://forgejo.org/) | N/A     | :white_check_mark:
 [GitHub](https://github.com/)   | :white_check_mark: | :white_check_mark:
 [GitLab](https://gitlab.com/)   | :white_check_mark: | :white_check_mark:
-[Forgejo](https://forgejo.org/) | N/A     | :white_check_mark:
+[Onedev](https://onedev.io/) | N/A     | :white_check_mark:
 
 No configuration is required to use one git host or another. Self host, ssh, it doesn't matter, `GitPortal` will take care of that work for you!
 

--- a/lua/gitportal/git.lua
+++ b/lua/gitportal/git.lua
@@ -141,22 +141,6 @@ local function get_base_git_host_url()
     return origin_url
 end
 
-function M.assemble_permalink(remote_url, branch_or_commit, git_path, git_host)
-    local permalink_map = {
-        [git_providers.github.name] = remote_url .. "/blob/" .. branch_or_commit.name .. "/" .. git_path,
-        [git_providers.gitlab.name] = remote_url .. "/-/blob/" .. branch_or_commit.name .. "/" .. git_path,
-        [git_providers.forgejo.name] = remote_url
-            .. "/src/"
-            .. branch_or_commit.type
-            .. "/"
-            .. branch_or_commit.name
-            .. "/"
-            .. git_path,
-    }
-
-    return permalink_map[git_host]
-end
-
 function M.create_url_params(start_line, end_line, git_host)
     local line_range_map = {
         [git_providers.github.name] = "#L" .. start_line .. "-L" .. end_line,
@@ -230,7 +214,7 @@ function M.get_git_url_for_current_file()
         return nil
     end
 
-    local permalink = M.assemble_permalink(remote_url, branch_or_commit, git_path, git_host)
+    local permalink = git_providers[git_host].assemble_permalink(remote_url, branch_or_commit, git_path)
 
     if vim.fn.mode() ~= "n" or config.options.always_include_current_line == true then
         local start_line, end_line = nv_utils.get_visual_selection_lines()

--- a/lua/gitportal/git.lua
+++ b/lua/gitportal/git.lua
@@ -113,16 +113,17 @@ function M.parse_origin_url(origin_url)
     end
 
     -- We didn't find a match in the traditional githosts, let's parse self hosted urls here!
-    if temp_url == origin_url and string.find(origin_url, "@", 0, true) then
+    if temp_url == origin_url then
         -- use case 1, self hosted ssh url begins with git@ssh
         if string.find(origin_url, "git@ssh", 0, true) then
             origin_url = origin_url:gsub("git@ssh%.", "https://")
-            origin_url = origin_url:gsub("%.com:", ".com/")
+        elseif string.find(origin_url, "ssh://", 0, true) then
+            origin_url = origin_url:gsub("ssh://", "https://")
         else
             -- Otherwise, just convert the ssh to a URL like normal
             origin_url = origin_url:gsub("git@", "https://")
-            origin_url = origin_url:gsub("%.com:", ".com/")
         end
+        origin_url = origin_url:gsub("%.com:", ".com/")
     end
 
     return origin_url

--- a/lua/gitportal/git.lua
+++ b/lua/gitportal/git.lua
@@ -53,6 +53,12 @@ function M.branch_or_commit_exists(branch_or_commit)
     return cli.run_command("git show-ref --heads " .. branch_or_commit)
 end
 
+function M.is_commit_hash(branch_or_commit)
+    local pattern = "^" .. string.rep("%x", 40) .. "$"
+    local match = branch_or_commit:match(pattern)
+    return match ~= nil and match ~= ""
+end
+
 function M.get_git_file_path()
     -- Gets a path of the file relative the the base git directory.
     -- Get the full path of the current file

--- a/lua/gitportal/git.lua
+++ b/lua/gitportal/git.lua
@@ -7,6 +7,11 @@ local git_root_patterns = { ".git" }
 local M = {}
 
 M.GIT_HOSTS = {
+    forgejo = {
+        name = "forgejo", -- forgejo is completely self hosted!
+        ssh_str = nil,
+        url = nil,
+    },
     github = {
         name = "github",
         ssh_str = "git@github.com",
@@ -16,11 +21,6 @@ M.GIT_HOSTS = {
         name = "gitlab",
         ssh_str = "git@gitlab.com",
         url = "https://gitlab.com/",
-    },
-    forgejo = {
-        name = "forgejo", -- forgejo is completely self hosted!
-        ssh_str = nil,
-        url = nil,
     },
 }
 

--- a/lua/gitportal/git.lua
+++ b/lua/gitportal/git.lua
@@ -141,24 +141,6 @@ local function get_base_git_host_url()
     return origin_url
 end
 
-function M.create_url_params(start_line, end_line, git_host)
-    local line_range_map = {
-        [git_providers.github.name] = "#L" .. start_line .. "-L" .. end_line,
-        [git_providers.gitlab.name] = "#L" .. start_line .. "-" .. end_line,
-        [git_providers.forgejo.name] = "#L" .. start_line .. "-L" .. end_line,
-    }
-
-    if start_line and end_line then
-        if start_line == end_line then
-            return "#L" .. start_line
-        else
-            return line_range_map[git_host]
-        end
-    end
-
-    return ""
-end
-
 function M.checkout_branch_or_commit(branch_or_commit)
     local switch_config = config.options.switch_branch_or_commit_upon_ingestion
     if switch_config == "never" then
@@ -218,7 +200,7 @@ function M.get_git_url_for_current_file()
 
     if vim.fn.mode() ~= "n" or config.options.always_include_current_line == true then
         local start_line, end_line = nv_utils.get_visual_selection_lines()
-        permalink = permalink .. M.create_url_params(start_line, end_line, git_host)
+        permalink = permalink .. git_providers[git_host].generate_url_params(start_line, end_line)
     end
 
     if permalink == nil then

--- a/lua/gitportal/git.lua
+++ b/lua/gitportal/git.lua
@@ -1,28 +1,11 @@
 local cli = require("gitportal.cli")
 local config = require("gitportal.config")
+local git_providers = require("gitportal.git_providers")
 local nv_utils = require("gitportal.nv_utils")
 
 local git_root_patterns = { ".git" }
 
 local M = {}
-
-M.GIT_HOSTS = {
-    forgejo = {
-        name = "forgejo", -- forgejo is completely self hosted!
-        ssh_str = nil,
-        url = nil,
-    },
-    github = {
-        name = "github",
-        ssh_str = "git@github.com",
-        url = "https://github.com/",
-    },
-    gitlab = {
-        name = "gitlab",
-        ssh_str = "git@gitlab.com",
-        url = "https://gitlab.com/",
-    },
-}
 
 function M.get_git_root_dir()
     -- Get the git root dir
@@ -56,7 +39,7 @@ function M.determine_git_host()
         end
     end
 
-    for host, host_info in pairs(M.GIT_HOSTS) do
+    for host, host_info in pairs(git_providers) do
         if string.find(origin_url, host_info.name, 0, true) then
             return host
         end
@@ -123,7 +106,7 @@ function M.parse_origin_url(origin_url)
 
     local temp_url = origin_url
     -- For any of the non-self-hosted git hosts, trim here
-    for _, host_info in pairs(M.GIT_HOSTS) do
+    for _, host_info in pairs(git_providers) do
         if host_info.ssh_str ~= nil and host_info.url ~= nil then
             origin_url = origin_url:gsub(host_info.ssh_str .. ":", host_info.url)
         end
@@ -160,9 +143,9 @@ end
 
 function M.assemble_permalink(remote_url, branch_or_commit, git_path, git_host)
     local permalink_map = {
-        [M.GIT_HOSTS.github.name] = remote_url .. "/blob/" .. branch_or_commit.name .. "/" .. git_path,
-        [M.GIT_HOSTS.gitlab.name] = remote_url .. "/-/blob/" .. branch_or_commit.name .. "/" .. git_path,
-        [M.GIT_HOSTS.forgejo.name] = remote_url
+        [git_providers.github.name] = remote_url .. "/blob/" .. branch_or_commit.name .. "/" .. git_path,
+        [git_providers.gitlab.name] = remote_url .. "/-/blob/" .. branch_or_commit.name .. "/" .. git_path,
+        [git_providers.forgejo.name] = remote_url
             .. "/src/"
             .. branch_or_commit.type
             .. "/"
@@ -176,9 +159,9 @@ end
 
 function M.create_url_params(start_line, end_line, git_host)
     local line_range_map = {
-        [M.GIT_HOSTS.github.name] = "#L" .. start_line .. "-L" .. end_line,
-        [M.GIT_HOSTS.gitlab.name] = "#L" .. start_line .. "-" .. end_line,
-        [M.GIT_HOSTS.forgejo.name] = "#L" .. start_line .. "-L" .. end_line,
+        [git_providers.github.name] = "#L" .. start_line .. "-L" .. end_line,
+        [git_providers.gitlab.name] = "#L" .. start_line .. "-" .. end_line,
+        [git_providers.forgejo.name] = "#L" .. start_line .. "-L" .. end_line,
     }
 
     if start_line and end_line then

--- a/lua/gitportal/git_providers.lua
+++ b/lua/gitportal/git_providers.lua
@@ -89,7 +89,7 @@ local GIT_PROVIDERS = {
         end,
         generate_url_params = function(start_line, end_line)
             if start_line == end_line then
-                return "#" .. start_line
+                return "#L" .. start_line
             else
                 return "#L" .. start_line .. "-" .. end_line
             end

--- a/lua/gitportal/git_providers.lua
+++ b/lua/gitportal/git_providers.lua
@@ -9,9 +9,6 @@
 
 local GIT_PROVIDERS = {
     onedev = {
-        name = "onedev", -- completely self hosted
-        ssh_str = nil,
-        url = nil,
         assemble_permalink = function(remote_url, branch_or_commit, git_path)
             return table.concat({
                 remote_url,
@@ -21,13 +18,13 @@ local GIT_PROVIDERS = {
                 git_path,
             })
         end,
+        name = "onedev", -- completely self hosted
         regex = nil,
+        ssh_str = nil,
+        url = nil,
     },
 
     forgejo = {
-        name = "forgejo", -- completely self hosted
-        ssh_str = nil,
-        url = nil,
         assemble_permalink = function(remote_url, branch_or_commit, git_path)
             return table.concat({
                 remote_url,
@@ -39,27 +36,30 @@ local GIT_PROVIDERS = {
                 git_path,
             })
         end,
+        name = "forgejo", -- completely self hosted
         regex = "/.+/([^/]+)/src/%a+/(.+)",
+        ssh_str = nil,
+        url = nil,
     },
 
     github = {
-        name = "github",
-        ssh_str = "git@github.com",
-        url = "https://github.com/",
         assemble_permalink = function(remote_url, branch_or_commit, git_path)
             return table.concat({ remote_url, "/blob/", branch_or_commit.name, "/", git_path })
         end,
+        name = "github",
         regex = "github.com/[^/]+/([^/]+)/blob/(.+)",
+        ssh_str = "git@github.com",
+        url = "https://github.com/",
     },
 
     gitlab = {
-        name = "gitlab",
-        ssh_str = "git@gitlab.com",
-        url = "https://gitlab.com/",
         assemble_permalink = function(remote_url, branch_or_commit, git_path)
             return table.concat({ remote_url, "/-/blob/", branch_or_commit.name, "/", git_path })
         end,
+        name = "gitlab",
         regex = "/.+/([^/]+)/%-/blob/(.+)",
+        ssh_str = "git@gitlab.com",
+        url = "https://gitlab.com/",
     },
 }
 

--- a/lua/gitportal/git_providers.lua
+++ b/lua/gitportal/git_providers.lua
@@ -13,7 +13,7 @@ local GIT_PROVIDERS = {
         ssh_str = nil,
         url = nil,
         assemble_permalink = function() end,
-        regex = "github.com/[^/]+/([^/]+)/blob/(.+)",
+        regex = nil,
     },
 
     forgejo = {
@@ -41,6 +41,7 @@ local GIT_PROVIDERS = {
         assemble_permalink = function(remote_url, branch_or_commit, git_path)
             return table.concat({ remote_url, "/blob/", branch_or_commit.name, "/", git_path })
         end,
+        regex = "github.com/[^/]+/([^/]+)/blob/(.+)",
     },
 
     gitlab = {

--- a/lua/gitportal/git_providers.lua
+++ b/lua/gitportal/git_providers.lua
@@ -8,22 +8,10 @@
 -- }
 
 local GIT_PROVIDERS = {
-    onedev = {
-        assemble_permalink = function(remote_url, branch_or_commit, git_path)
-            return table.concat({
-                remote_url,
-                "/~files/",
-                branch_or_commit.name,
-                "/",
-                git_path,
-            })
-        end,
-        name = "onedev", -- completely self hosted
-        regex = nil,
-        ssh_str = nil,
-        url = nil,
-    },
 
+    -- ****
+    -- FORGEJO
+    -- ****
     forgejo = {
         assemble_permalink = function(remote_url, branch_or_commit, git_path)
             return table.concat({
@@ -36,15 +24,24 @@ local GIT_PROVIDERS = {
                 git_path,
             })
         end,
+        generate_url_params = function(start_line, end_line)
+            return "#L" .. start_line .. "-L" .. end_line
+        end,
         name = "forgejo", -- completely self hosted
         regex = "/.+/([^/]+)/src/%a+/(.+)",
         ssh_str = nil,
         url = nil,
     },
 
+    -- ****
+    -- GITHUB
+    -- ****
     github = {
         assemble_permalink = function(remote_url, branch_or_commit, git_path)
             return table.concat({ remote_url, "/blob/", branch_or_commit.name, "/", git_path })
+        end,
+        generate_url_params = function(start_line, end_line)
+            return "#L" .. start_line .. "-L" .. end_line
         end,
         name = "github",
         regex = "github.com/[^/]+/([^/]+)/blob/(.+)",
@@ -52,14 +49,42 @@ local GIT_PROVIDERS = {
         url = "https://github.com/",
     },
 
+    -- ****
+    -- GITLAB
+    -- ****
     gitlab = {
         assemble_permalink = function(remote_url, branch_or_commit, git_path)
             return table.concat({ remote_url, "/-/blob/", branch_or_commit.name, "/", git_path })
+        end,
+        generate_url_params = function(start_line, end_line)
+            return "#L" .. start_line .. "-" .. end_line
         end,
         name = "gitlab",
         regex = "/.+/([^/]+)/%-/blob/(.+)",
         ssh_str = "git@gitlab.com",
         url = "https://gitlab.com/",
+    },
+
+    -- ****
+    -- ONEDEV
+    -- ****
+    onedev = {
+        assemble_permalink = function(remote_url, branch_or_commit, git_path)
+            return table.concat({
+                remote_url,
+                "/~files/",
+                branch_or_commit.name,
+                "/",
+                git_path,
+            })
+        end,
+        generate_url_params = function(start_line, end_line)
+            return "position=source-" .. start_line .. ".1-" .. end_line + 1 .. ".1"
+        end,
+        name = "onedev", -- completely self hosted
+        regex = nil,
+        ssh_str = nil,
+        url = nil,
     },
 }
 

--- a/lua/gitportal/git_providers.lua
+++ b/lua/gitportal/git_providers.lua
@@ -1,0 +1,24 @@
+local GIT_PROVIDERS = {
+    onedev = {
+        name = "onedev", -- completely self hosted
+        ssh_str = nil,
+        url = nil,
+    },
+    forgejo = {
+        name = "forgejo", -- completely self hosted
+        ssh_str = nil,
+        url = nil,
+    },
+    github = {
+        name = "github",
+        ssh_str = "git@github.com",
+        url = "https://github.com/",
+    },
+    gitlab = {
+        name = "gitlab",
+        ssh_str = "git@gitlab.com",
+        url = "https://gitlab.com/",
+    },
+}
+
+return GIT_PROVIDERS

--- a/lua/gitportal/git_providers.lua
+++ b/lua/gitportal/git_providers.lua
@@ -25,7 +25,11 @@ local GIT_PROVIDERS = {
             })
         end,
         generate_url_params = function(start_line, end_line)
-            return "#L" .. start_line .. "-L" .. end_line
+            if start_line == end_line then
+                return "#L" .. start_line
+            else
+                return "#L" .. start_line .. "-L" .. end_line
+            end
         end,
         name = "forgejo", -- completely self hosted
         regex = "/.+/([^/]+)/src/%a+/(.+)",
@@ -41,7 +45,11 @@ local GIT_PROVIDERS = {
             return table.concat({ remote_url, "/blob/", branch_or_commit.name, "/", git_path })
         end,
         generate_url_params = function(start_line, end_line)
-            return "#L" .. start_line .. "-L" .. end_line
+            if start_line == end_line then
+                return "#L" .. start_line
+            else
+                return "#L" .. start_line .. "-L" .. end_line
+            end
         end,
         name = "github",
         regex = "github.com/[^/]+/([^/]+)/blob/(.+)",
@@ -57,7 +65,11 @@ local GIT_PROVIDERS = {
             return table.concat({ remote_url, "/-/blob/", branch_or_commit.name, "/", git_path })
         end,
         generate_url_params = function(start_line, end_line)
-            return "#L" .. start_line .. "-" .. end_line
+            if start_line == end_line then
+                return "#" .. start_line
+            else
+                return "#L" .. start_line .. "-" .. end_line
+            end
         end,
         name = "gitlab",
         regex = "/.+/([^/]+)/%-/blob/(.+)",
@@ -79,10 +91,10 @@ local GIT_PROVIDERS = {
             })
         end,
         generate_url_params = function(start_line, end_line)
-            return "position=source-" .. start_line .. ".1-" .. end_line + 1 .. ".1"
+            return "?position=source-" .. start_line .. ".1-" .. end_line + 1 .. ".1"
         end,
         name = "onedev", -- completely self hosted
-        regex = nil,
+        regex = "/.+/([^/]+)/~files/(.+)",
         ssh_str = nil,
         url = nil,
     },

--- a/lua/gitportal/git_providers.lua
+++ b/lua/gitportal/git_providers.lua
@@ -75,7 +75,7 @@ local GIT_PROVIDERS = {
         end,
         name = "github",
         parse_line_range = standard_line_range_parser,
-        regex = "github.com/[^/]+/([^/]+)/blob/(.+)",
+        regex = "/.+/[^/]+/([^/]+)/blob/(.+)",
         ssh_str = "git@github.com",
         url = "https://github.com/",
     },

--- a/lua/gitportal/git_providers.lua
+++ b/lua/gitportal/git_providers.lua
@@ -7,6 +7,28 @@
 --     url = "https://github.com/", -- beginning string that appears in https origin URL for host (N/A if self hosted)
 -- }
 
+local function standard_line_range_parser(url)
+    local start_line = nil
+    local end_line = nil
+
+    -- TODO: Is this robust enough?
+    if string.find(url, "#L", 0, true) ~= nil then
+        start_line = url:match("#L(%d+)")
+        if string.find(url, "-", 0, true) ~= nil then
+            end_line = url:match("#L%d+%-L?(%d+)$")
+        end
+    end
+
+    if start_line ~= nil then
+        if end_line == nil then
+            end_line = start_line
+        end
+        start_line = tonumber(start_line)
+        end_line = tonumber(end_line)
+    end
+    return start_line, end_line
+end
+
 local GIT_PROVIDERS = {
 
     -- ****
@@ -32,6 +54,7 @@ local GIT_PROVIDERS = {
             end
         end,
         name = "forgejo", -- completely self hosted
+        parse_line_range = standard_line_range_parser,
         regex = "/.+/([^/]+)/src/%a+/(.+)",
         ssh_str = nil,
         url = nil,
@@ -52,6 +75,7 @@ local GIT_PROVIDERS = {
             end
         end,
         name = "github",
+        parse_line_range = standard_line_range_parser,
         regex = "github.com/[^/]+/([^/]+)/blob/(.+)",
         ssh_str = "git@github.com",
         url = "https://github.com/",
@@ -71,6 +95,7 @@ local GIT_PROVIDERS = {
                 return "#L" .. start_line .. "-" .. end_line
             end
         end,
+        parse_line_range = standard_line_range_parser,
         name = "gitlab",
         regex = "/.+/([^/]+)/%-/blob/(.+)",
         ssh_str = "git@gitlab.com",
@@ -94,6 +119,7 @@ local GIT_PROVIDERS = {
             return "?position=source-" .. start_line .. ".1-" .. end_line + 1 .. ".1"
         end,
         name = "onedev", -- completely self hosted
+        parse_line_range = function(url) end,
         regex = "/.+/([^/]+)/~files/(.+)",
         ssh_str = nil,
         url = nil,

--- a/lua/gitportal/git_providers.lua
+++ b/lua/gitportal/git_providers.lua
@@ -1,23 +1,52 @@
+-- CONFIGURATION FOR ALL SUPPORT GIT PROVIDERS
+--
+-- This follows the following format
+-- github = {
+--     name = github, -- host name
+--     ssh_str = "git@github.com", -- beginning string that appears in SSH origin URL for host for (N/A if self hosted)
+--     url = "https://github.com/", -- beginning string that appears in https origin URL for host (N/A if self hosted)
+-- }
+
 local GIT_PROVIDERS = {
     onedev = {
         name = "onedev", -- completely self hosted
         ssh_str = nil,
         url = nil,
     },
+
     forgejo = {
         name = "forgejo", -- completely self hosted
         ssh_str = nil,
         url = nil,
+        assemble_permalink = function(remote_url, branch_or_commit, git_path)
+            return table.concat({
+                remote_url,
+                "/src/",
+                branch_or_commit.type,
+                "/",
+                branch_or_commit.name,
+                "/",
+                git_path,
+            })
+        end,
     },
+
     github = {
         name = "github",
         ssh_str = "git@github.com",
         url = "https://github.com/",
+        assemble_permalink = function(remote_url, branch_or_commit, git_path)
+            return table.concat({ remote_url, "/blob/", branch_or_commit.name, "/", git_path })
+        end,
     },
+
     gitlab = {
         name = "gitlab",
         ssh_str = "git@gitlab.com",
         url = "https://gitlab.com/",
+        assemble_permalink = function(remote_url, branch_or_commit, git_path)
+            return table.concat({ remote_url, "/-/blob/", branch_or_commit.name, "/", git_path })
+        end,
     },
 }
 

--- a/lua/gitportal/git_providers.lua
+++ b/lua/gitportal/git_providers.lua
@@ -8,8 +8,7 @@
 -- }
 
 local function standard_line_range_parser(url)
-    local start_line = nil
-    local end_line = nil
+    local start_line, end_line = nil, nil
 
     -- TODO: Is this robust enough?
     if string.find(url, "#L", 0, true) ~= nil then
@@ -119,7 +118,17 @@ local GIT_PROVIDERS = {
             return "?position=source-" .. start_line .. ".1-" .. end_line + 1 .. ".1"
         end,
         name = "onedev", -- completely self hosted
-        parse_line_range = function(url) end,
+        parse_line_range = function(url)
+            local first_line, second_line = nil, nil
+            if string.find(url, "position=source", 0, true) ~= nil then
+                first_line, second_line = url:match("position=source%-(%d+)%.%d+%-(%d+)%.")
+            end
+            if first_line ~= nil and second_line ~= nil then
+                first_line = tonumber(first_line)
+                second_line = tonumber(second_line)
+            end
+            return first_line, second_line
+        end,
         regex = "/.+/([^/]+)/~files/(.+)",
         ssh_str = nil,
         url = nil,

--- a/lua/gitportal/git_providers.lua
+++ b/lua/gitportal/git_providers.lua
@@ -12,7 +12,15 @@ local GIT_PROVIDERS = {
         name = "onedev", -- completely self hosted
         ssh_str = nil,
         url = nil,
-        assemble_permalink = function() end,
+        assemble_permalink = function(remote_url, branch_or_commit, git_path)
+            return table.concat({
+                remote_url,
+                "/~files/",
+                branch_or_commit.name,
+                "/",
+                git_path,
+            })
+        end,
         regex = nil,
     },
 

--- a/lua/gitportal/git_providers.lua
+++ b/lua/gitportal/git_providers.lua
@@ -12,6 +12,8 @@ local GIT_PROVIDERS = {
         name = "onedev", -- completely self hosted
         ssh_str = nil,
         url = nil,
+        assemble_permalink = function() end,
+        regex = "github.com/[^/]+/([^/]+)/blob/(.+)",
     },
 
     forgejo = {
@@ -29,6 +31,7 @@ local GIT_PROVIDERS = {
                 git_path,
             })
         end,
+        regex = "/.+/([^/]+)/src/%a+/(.+)",
     },
 
     github = {
@@ -47,6 +50,7 @@ local GIT_PROVIDERS = {
         assemble_permalink = function(remote_url, branch_or_commit, git_path)
             return table.concat({ remote_url, "/-/blob/", branch_or_commit.name, "/", git_path })
         end,
+        regex = "/.+/([^/]+)/%-/blob/(.+)",
     },
 }
 

--- a/lua/gitportal/url_utils.lua
+++ b/lua/gitportal/url_utils.lua
@@ -32,30 +32,6 @@ local function parse_url_remainder(remainder)
     return branch_or_commit, cleaned_file_path
 end
 
-local function parse_line_range(url)
-    -- Given a url, parse the optional line range from the end of the URL itself.
-    -- These may looks like #L5-L11 or #L5-11, or may not be present at all.
-    local start_line = nil
-    local end_line = nil
-
-    -- TODO: Is this robust enough?
-    if string.find(url, "#L", 0, true) ~= nil then
-        start_line = url:match("#L(%d+)")
-        if string.find(url, "-", 0, true) ~= nil then
-            end_line = url:match("#L%d+%-L?(%d+)$")
-        end
-    end
-
-    if start_line ~= nil then
-        if end_line == nil then
-            end_line = start_line
-        end
-        start_line = tonumber(start_line)
-        end_line = tonumber(end_line)
-    end
-    return start_line, end_line
-end
-
 local function parse_git_provider_url(url, githost)
     local repo, remainder = url:match(git_providers[githost].regex)
     local branch_or_commit, file_path = parse_url_remainder(remainder)
@@ -67,7 +43,7 @@ function M.parse_githost_url(url)
     local githost = git_utils.determine_git_host()
 
     local repo, branch_or_commit, file_path = parse_git_provider_url(url, githost)
-    local start_line, end_line = parse_line_range(url)
+    local start_line, end_line = git_providers[githost].parse_line_range(url)
 
     if not repo or not branch_or_commit or not file_path then
         cli.log_error("Could not successfully parse githost url!")

--- a/lua/gitportal/url_utils.lua
+++ b/lua/gitportal/url_utils.lua
@@ -5,7 +5,7 @@ local lua_utils = require("gitportal.lua_utils")
 
 local M = {}
 
-local function parse_url_remainder(remainder)
+local function parse_url_remainder(remainder, githost)
     -- At this point we have something like
     -- main/lua/gitportal/cli.lua#L45-L55 or master/public/index.html?ref_type=heads#L5-11
     -- This is everything after /blob/. Problem is, branches can have a '/' in them, so we need to carefully
@@ -23,6 +23,10 @@ local function parse_url_remainder(remainder)
             -- Remaining parts are the file path
             file_path = table.concat(url_parts, "/", i + 1)
             break
+        elseif githost == git_providers.onedev.name and git_utils.is_commit_hash(branch_or_commit) then
+            -- edge case for onedev urls that ALWAYS have commit hash in them
+            file_path = table.concat(url_parts, "/", i + 1)
+            break
         end
     end
 
@@ -34,7 +38,7 @@ end
 
 local function parse_git_provider_url(url, githost)
     local repo, remainder = url:match(git_providers[githost].regex)
-    local branch_or_commit, file_path = parse_url_remainder(remainder)
+    local branch_or_commit, file_path = parse_url_remainder(remainder, githost)
 
     return repo, branch_or_commit, file_path
 end

--- a/lua/gitportal/url_utils.lua
+++ b/lua/gitportal/url_utils.lua
@@ -1,5 +1,5 @@
 local cli = require("gitportal.cli")
-local config = require("gitportal.config")
+local git_providers = require("gitportal.git_providers")
 local git_utils = require("gitportal.git")
 local lua_utils = require("gitportal.lua_utils")
 
@@ -85,9 +85,9 @@ end
 
 local function get_githost_parse_func(githost)
     local parse_func_map = {
-        [git_utils.GIT_HOSTS.github.name] = parse_github_url,
-        [git_utils.GIT_HOSTS.gitlab.name] = parse_gitlab_url,
-        [git_utils.GIT_HOSTS.forgejo.name] = parse_forgejo_url,
+        [git_providers.github.name] = parse_github_url,
+        [git_providers.gitlab.name] = parse_gitlab_url,
+        [git_providers.forgejo.name] = parse_forgejo_url,
     }
 
     local parse_func = parse_func_map[githost]

--- a/tests/run_tests.lua
+++ b/tests/run_tests.lua
@@ -4,6 +4,7 @@ require("tests.test_cli")
 require("tests.test_git")
 require("tests.test_git_remote_urls")
 require("tests.test_url_utils")
+require("tests.test_providers")
 
 local lu = require("luaunit")
 

--- a/tests/test_git.lua
+++ b/tests/test_git.lua
@@ -1,6 +1,7 @@
 local cli = require("gitportal.cli")
 local config = require("gitportal.config")
 local git = require("gitportal.git")
+local git_providers = require("gitportal.git_providers")
 local lu = require("luaunit")
 
 TestGit = {}
@@ -62,10 +63,10 @@ function TestGit:setUp()
 
     ---@diagnostic disable-next-line: duplicate-set-field
     git.get_origin_url = function()
-        if self.current_git_host == git.GIT_HOSTS.github.name then
-            return git.GIT_HOSTS.github.url
-        elseif self.current_git_host == git.GIT_HOSTS.gitlab.name then
-            return git.GIT_HOSTS.gitlab.url
+        if self.current_git_host == git_providers.github.name then
+            return git_providers.github.url
+        elseif self.current_git_host == git_providers.gitlab.name then
+            return git_providers.gitlab.url
         else
             return self.current_git_host
         end
@@ -113,11 +114,11 @@ function TestGit:test_get_branch_or_commit()
 end
 
 function TestGit:test_determine_git_host()
-    self.current_git_host = git.GIT_HOSTS.github.name
+    self.current_git_host = git_providers.github.name
     local git_host = git.determine_git_host()
     lu.assertEquals(git_host, self.current_git_host)
 
-    self.current_git_host = git.GIT_HOSTS.gitlab.name
+    self.current_git_host = git_providers.gitlab.name
     git_host = git.determine_git_host()
     lu.assertEquals(git_host, self.current_git_host)
 end

--- a/tests/test_git.lua
+++ b/tests/test_git.lua
@@ -85,6 +85,17 @@ function TestGit:test_get_git_base_directory()
     lu.assertEquals(git.get_git_base_directory(), "gitportal.nvim")
 end
 
+function TestGit:test_is_commit_hash()
+    -- valid commit hash
+    lu.assertEquals(true, git.is_commit_hash("7e14d7545918b9167dd65bea8da454d2e389df5b"))
+    -- invalid, contains a /
+    lu.assertEquals(false, git.is_commit_hash("7e14d7545918b9167dd/5bea8da454d2e389df5b"))
+    -- invalid, too long
+    lu.assertEquals(false, git.is_commit_hash("7e14d7545918b9167dd55bea8da454d2e389df5b1"))
+    -- invalid, too short!
+    lu.assertEquals(false, git.is_commit_hash("7e1918b9167dd55bea8da454d2e389df5b1"))
+end
+
 function TestGit:test_get_git_file_path()
     lu.assertEquals(git.get_git_file_path(), "lua/gitportal/cli.lua")
 end

--- a/tests/test_providers/init.lua
+++ b/tests/test_providers/init.lua
@@ -1,0 +1,4 @@
+require("tests.test_providers.test_github")
+require("tests.test_providers.test_gitlab")
+require("tests.test_providers.test_forgejo")
+require("tests.test_providers.test_onedev")

--- a/tests/test_providers/test_forgejo.lua
+++ b/tests/test_providers/test_forgejo.lua
@@ -1,0 +1,48 @@
+local git_providers = require("gitportal.git_providers")
+local lu = require("luaunit")
+
+local complete_url = "http://localhost:3000/trevorhauter/advanced-app/src/branch/main/components/test.py"
+local remote_url = "http://localhost:3000/trevorhauter/advanced-app"
+local branch_or_commit = { name = "main", type = "branch" }
+local git_path = "components/test.py"
+local provider = git_providers.forgejo
+
+TestForgejo = {}
+
+function TestForgejo:test_github_permalink_assembly()
+    local permalink = provider.assemble_permalink(remote_url, branch_or_commit, git_path)
+    lu.assertEquals(complete_url, permalink)
+end
+
+function TestForgejo:test_url_params()
+    local single_line_param = provider.generate_url_params(5, 5)
+    lu.assertEquals("#L5", single_line_param)
+
+    local line_range_param = provider.generate_url_params(5, 15)
+    lu.assertEquals("#L5-L15", line_range_param)
+end
+
+function TestForgejo:test_string_attributes()
+    lu.assertEquals(provider.name, "forgejo")
+    lu.assertEquals(provider.ssh_str, nil)
+    lu.assertEquals(provider.url, nil)
+end
+
+function TestForgejo:test_single_line_parsing()
+    local start_line, end_line = provider.parse_line_range("www.example.com#L5")
+    lu.assertEquals(start_line, 5)
+    lu.assertEquals(end_line, 5)
+end
+
+function TestForgejo:test_multi_line_parsing()
+    local start_line, end_line = provider.parse_line_range("www.example.com#L5-L15")
+    lu.assertEquals(start_line, 5)
+    lu.assertEquals(end_line, 15)
+end
+
+function TestForgejo:test_regex()
+    local url = complete_url
+    local repo, remainder = url:match(provider.regex)
+    lu.assertEquals(repo, "advanced-app")
+    lu.assertEquals(remainder, "main/components/test.py")
+end

--- a/tests/test_providers/test_github.lua
+++ b/tests/test_providers/test_github.lua
@@ -1,0 +1,48 @@
+local git_providers = require("gitportal.git_providers")
+local lu = require("luaunit")
+
+local complete_url = "https://github.com/trevorhauter/gitportal.nvim/blob/main/lua/gitportal/cli.lua"
+local remote_url = "https://github.com/trevorhauter/gitportal.nvim"
+local branch_or_commit = { name = "main", type = "branch" }
+local git_path = "lua/gitportal/cli.lua"
+local provider = git_providers.github
+
+TestGitHub = {}
+
+function TestGitHub:test_github_permalink_assembly()
+    local permalink = provider.assemble_permalink(remote_url, branch_or_commit, git_path)
+    lu.assertEquals(complete_url, permalink)
+end
+
+function TestGitHub:test_url_params()
+    local single_line_param = provider.generate_url_params(5, 5)
+    lu.assertEquals("#L5", single_line_param)
+
+    local line_range_param = provider.generate_url_params(5, 15)
+    lu.assertEquals("#L5-L15", line_range_param)
+end
+
+function TestGitHub:test_string_attributes()
+    lu.assertEquals(provider.name, "github")
+    lu.assertEquals(provider.ssh_str, "git@github.com")
+    lu.assertEquals(provider.url, "https://github.com/")
+end
+
+function TestGitHub:test_single_line_parsing()
+    local start_line, end_line = provider.parse_line_range("www.example.com#L5")
+    lu.assertEquals(start_line, 5)
+    lu.assertEquals(end_line, 5)
+end
+
+function TestGitHub:test_multi_line_parsing()
+    local start_line, end_line = provider.parse_line_range("www.example.com#L5-L15")
+    lu.assertEquals(start_line, 5)
+    lu.assertEquals(end_line, 15)
+end
+
+function TestGitHub:test_regex()
+    local url = complete_url
+    local repo, remainder = url:match(provider.regex)
+    lu.assertEquals(repo, "gitportal.nvim")
+    lu.assertEquals(remainder, "main/lua/gitportal/cli.lua")
+end

--- a/tests/test_providers/test_gitlab.lua
+++ b/tests/test_providers/test_gitlab.lua
@@ -1,0 +1,48 @@
+local git_providers = require("gitportal.git_providers")
+local lu = require("luaunit")
+
+local complete_url = "https://gitlab.com/gitportal/gitlab-test/-/blob/master/public/index.html"
+local remote_url = "https://gitlab.com/gitportal/gitlab-test"
+local branch_or_commit = { name = "master", type = "branch" }
+local git_path = "public/index.html"
+local provider = git_providers.gitlab
+
+TestGitLab = {}
+
+function TestGitLab:test_github_permalink_assembly()
+    local permalink = provider.assemble_permalink(remote_url, branch_or_commit, git_path)
+    lu.assertEquals(complete_url, permalink)
+end
+
+function TestGitLab:test_url_params()
+    local single_line_param = provider.generate_url_params(5, 5)
+    lu.assertEquals("#L5", single_line_param)
+
+    local line_range_param = provider.generate_url_params(5, 15)
+    lu.assertEquals("#L5-15", line_range_param)
+end
+
+function TestGitLab:test_string_attributes()
+    lu.assertEquals(provider.name, "gitlab")
+    lu.assertEquals(provider.ssh_str, "git@gitlab.com")
+    lu.assertEquals(provider.url, "https://gitlab.com/")
+end
+
+function TestGitLab:test_single_line_parsing()
+    local start_line, end_line = provider.parse_line_range("www.example.com#L5")
+    lu.assertEquals(start_line, 5)
+    lu.assertEquals(end_line, 5)
+end
+
+function TestGitLab:test_multi_line_parsing()
+    local start_line, end_line = provider.parse_line_range("www.example.com#L5-15")
+    lu.assertEquals(start_line, 5)
+    lu.assertEquals(end_line, 15)
+end
+
+function TestGitLab:test_regex()
+    local url = complete_url
+    local repo, remainder = url:match(provider.regex)
+    lu.assertEquals(repo, "gitlab-test")
+    lu.assertEquals(remainder, "master/public/index.html")
+end

--- a/tests/test_providers/test_onedev.lua
+++ b/tests/test_providers/test_onedev.lua
@@ -1,0 +1,49 @@
+local git_providers = require("gitportal.git_providers")
+local lu = require("luaunit")
+
+local complete_url =
+    "http://localhost:6610/advanced-app/~files/3130016177a84bf5e0f36c7c70ad434dca121d4b/components/main.jsx"
+local remote_url = "http://localhost:6610/advanced-app"
+local branch_or_commit = { name = "3130016177a84bf5e0f36c7c70ad434dca121d4b", type = "commit" }
+local git_path = "components/main.jsx"
+local provider = git_providers.onedev
+
+TestOneDev = {}
+
+function TestOneDev:test_github_permalink_assembly()
+    local permalink = provider.assemble_permalink(remote_url, branch_or_commit, git_path)
+    lu.assertEquals(complete_url, permalink)
+end
+
+function TestOneDev:test_url_params()
+    local single_line_param = provider.generate_url_params(5, 5)
+    lu.assertEquals("?position=source-5.1-6.1", single_line_param)
+
+    local line_range_param = provider.generate_url_params(5, 15)
+    lu.assertEquals("?position=source-5.1-16.1", line_range_param)
+end
+
+function TestOneDev:test_string_attributes()
+    lu.assertEquals(provider.name, "onedev")
+    lu.assertEquals(provider.ssh_str, nil)
+    lu.assertEquals(provider.url, nil)
+end
+
+function TestOneDev:test_single_line_parsing()
+    local start_line, end_line = provider.parse_line_range("www.example.com?position=source-5.1-5.14-1")
+    lu.assertEquals(start_line, 5)
+    lu.assertEquals(end_line, 5)
+end
+
+function TestOneDev:test_multi_line_parsing()
+    local start_line, end_line = provider.parse_line_range("www.example.com?position=source-5.1-15.14-1")
+    lu.assertEquals(start_line, 5)
+    lu.assertEquals(end_line, 15)
+end
+
+function TestOneDev:test_regex()
+    local url = complete_url
+    local repo, remainder = url:match(provider.regex)
+    lu.assertEquals(repo, "advanced-app")
+    lu.assertEquals(remainder, "3130016177a84bf5e0f36c7c70ad434dca121d4b/components/main.jsx")
+end

--- a/tests/test_url_utils.lua
+++ b/tests/test_url_utils.lua
@@ -290,19 +290,21 @@ function TestParseGitHostUrl:test_self_host_onedev_url_https()
     test_githost_url(base_url, expected_result, onedev_single_line_info, onedev_line_range_info)
 end
 
---function TestParseGitHostUrl:test_self_host_forgejo_url_ssh()
---self.origin_url = "git@localhost:trevorhauter/advanced-app.git"
---config.options.git_provider_map = { ["git@localhost:trevorhauter/advanced-app.git"] = "forgejo" }
---local base_url = "http://localhost:3000/trevorhauter/advanced-app/src/branch/main/components/test.py"
---local expected_result = {
---repo = "advanced-app",
---branch_or_commit = "main",
---file_path = "components/test.py",
---start_line = nil,
---end_line = nil,
---}
---test_githost_url(base_url, expected_result, forgejo_single_line_info, forgejo_line_range_info)
---end
+function TestParseGitHostUrl:test_self_host_onedev_url_ssh()
+    self.origin_url = "ssh://localhost:6610/advanced-app"
+    config.options.git_platform = nil
+    config.options.git_provider_map = { ["ssh://localhost:6610/advanced-app"] = "onedev" }
+    local base_url =
+        "http://localhost:6610/advanced-app/~files/3130016177a84bf5e0f36c7c70ad434dca121d4b/components/main.jsx"
+    local expected_result = {
+        repo = "advanced-app",
+        branch_or_commit = "3130016177a84bf5e0f36c7c70ad434dca121d4b",
+        file_path = "components/main.jsx",
+        start_line = nil,
+        end_line = nil,
+    }
+    test_githost_url(base_url, expected_result, onedev_single_line_info, onedev_line_range_info)
+end
 -- ****
 -- End onedev tests
 -- ****

--- a/tests/test_url_utils.lua
+++ b/tests/test_url_utils.lua
@@ -61,6 +61,7 @@ function TestParseGitHostUrl:setUp()
         if
             param == "376596caaa683e6f607c45d6fe1b6834070c517a"
             or param == "7e14d7545918b9167dd65bea8da454d2e389df5b"
+            or param == "3130016177a84bf5e0f36c7c70ad434dca121d4b"
         then
             return "asdefjkl;asdfjkl;"
         end
@@ -265,6 +266,45 @@ end
 
 -- ****
 -- End forgejo tests
+-- ****
+
+-- ****
+-- START onedev tests
+-- ****
+local onedev_single_line_info = { url = "?position=source-45.1-45.14-1", start_line = 45 }
+local onedev_line_range_info = { url = "?position=source-50.1-55.14-1", start_line = 50, end_line = 55 }
+
+function TestParseGitHostUrl:test_self_host_onedev_url_https()
+    config.options.git_platform = nil
+    self.origin_url = "http://localhost:6610/advanced-app"
+    config.options.git_provider_map = { ["http://localhost:6610/advanced-app"] = "onedev" }
+    local base_url =
+        "http://localhost:6610/advanced-app/~files/3130016177a84bf5e0f36c7c70ad434dca121d4b/components/main.jsx"
+    local expected_result = {
+        repo = "advanced-app",
+        branch_or_commit = "3130016177a84bf5e0f36c7c70ad434dca121d4b",
+        file_path = "components/main.jsx",
+        start_line = nil,
+        end_line = nil,
+    }
+    test_githost_url(base_url, expected_result, onedev_single_line_info, onedev_line_range_info)
+end
+
+--function TestParseGitHostUrl:test_self_host_forgejo_url_ssh()
+--self.origin_url = "git@localhost:trevorhauter/advanced-app.git"
+--config.options.git_provider_map = { ["git@localhost:trevorhauter/advanced-app.git"] = "forgejo" }
+--local base_url = "http://localhost:3000/trevorhauter/advanced-app/src/branch/main/components/test.py"
+--local expected_result = {
+--repo = "advanced-app",
+--branch_or_commit = "main",
+--file_path = "components/test.py",
+--start_line = nil,
+--end_line = nil,
+--}
+--test_githost_url(base_url, expected_result, forgejo_single_line_info, forgejo_line_range_info)
+--end
+-- ****
+-- End onedev tests
 -- ****
 
 -- ****

--- a/tests/test_url_utils.lua
+++ b/tests/test_url_utils.lua
@@ -290,6 +290,24 @@ function TestParseGitHostUrl:test_self_host_onedev_url_https()
     test_githost_url(base_url, expected_result, onedev_single_line_info, onedev_line_range_info)
 end
 
+function TestParseGitHostUrl:test_self_host_onedev_url_https_random_commit()
+    -- Onedev always has a commit in the url, oftentimes the user is on a branch.
+    -- Onedev has an edge case built in that will recognize and account for this
+    config.options.git_platform = nil
+    self.origin_url = "http://localhost:6610/advanced-app"
+    config.options.git_provider_map = { ["http://localhost:6610/advanced-app"] = "onedev" }
+    local base_url =
+        "http://localhost:6610/advanced-app/~files/3130016177a84bf5e0f36c7c70ad434dca129999/components/main.jsx"
+    local expected_result = {
+        repo = "advanced-app",
+        branch_or_commit = "3130016177a84bf5e0f36c7c70ad434dca129999",
+        file_path = "components/main.jsx",
+        start_line = nil,
+        end_line = nil,
+    }
+    test_githost_url(base_url, expected_result, onedev_single_line_info, onedev_line_range_info)
+end
+
 function TestParseGitHostUrl:test_self_host_onedev_url_ssh()
     self.origin_url = "ssh://localhost:6610/advanced-app"
     config.options.git_platform = nil


### PR DESCRIPTION
### TODO
- [x] Refactor git provider information to live in one centralized place - core code should not have to move around when a new provider is aded
- [x] Migrate url parse funcs to central place
- [x] Add url parse method for onedev
- [x] Update parse line range url method
- [x] Add tests for onedev
- [x] Make sure test coverage exists for URL params
- [x] Add unit tests for is_commit_hash
- [ ] Investigate what other core test coverage may need to exist
    - [ ] ... add that test coverage 
- [ ] Confirm full support for one dev is complete
- [ ] Write out test plan below to confirm this won't break anything... Then test it 