### PR TITLE
Update configuration to support base URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ If you wish to keep these defaults, no configuration is required. To customize t
 
     -- Map of origin urls to git providers 
     -- (default: automatically determined by GitPortal, required for self hosted instances)
-    -- {["origin_url"] = { provider = "gitlab", base_url = "https://customdomain.dev"}}
+    -- Ex. {["origin_url"] = { provider = "gitlab", base_url = "https://customdomain.dev"}}
     git_provider_map = nil,
 }
 ```

--- a/README.md
+++ b/README.md
@@ -69,8 +69,9 @@ If you wish to keep these defaults, no configuration is required. To customize t
     browser_command = nil, -- (override only if necessary, not recommended)
 
     -- Map of origin urls to git providers 
-    -- (default: automatically determined by GitPortal, recommended for self hosted instances)
-    git_provider_map = nil, -- {["origin_url"] = { provider = "github", base_url = "https://customdomain.dev"}}
+    -- (default: automatically determined by GitPortal, required for self hosted instances)
+    -- {["origin_url"] = { provider = "gitlab", base_url = "https://customdomain.dev"}}
+    git_provider_map = nil,
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -69,8 +69,8 @@ If you wish to keep these defaults, no configuration is required. To customize t
     browser_command = nil, -- (override only if necessary, not recommended)
 
     -- Map of origin urls to git providers 
-    -- (default: automatically determined by GitPortal, only required for self hosting)
-    git_provider_map = nil, -- {["origin_url"] = "(github|gitlab)"}   
+    -- (default: automatically determined by GitPortal, recommended for self hosted instances)
+    git_provider_map = nil, -- {["origin_url"] = { provider = "github", base_url = "https://customdomain.dev"}}
 }
 ```
 

--- a/lua/gitportal/config.lua
+++ b/lua/gitportal/config.lua
@@ -7,7 +7,6 @@ local default = {
     always_include_current_line = false,
     switch_branch_or_commit_upon_ingestion = "always", -- Can be "always", "ask_first", or "never"
     browser_command = nil, -- String of the command used on command line to open link in browser
-    git_platform = nil, -- Deprecated
     git_provider_map = nil, -- Map of urls to their git providers
 }
 
@@ -16,10 +15,6 @@ M.options = default
 function M.setup(options)
     -- Merge user options with default options
     M.options = vim.tbl_deep_extend("force", {}, default, options or {})
-
-    if M.options.git_platform then
-        cli.log_warning("git_platform is deprecated. Please use git_provider_map instead.")
-    end
 
     local commands = {
         browse_file = function()

--- a/lua/gitportal/git.lua
+++ b/lua/gitportal/git.lua
@@ -33,10 +33,6 @@ function M.get_origin_url()
 end
 
 function M.determine_git_host()
-    if config.options.git_platform ~= nil then
-        return config.options.git_platform
-    end
-
     local origin_url = M.get_origin_url()
     if origin_url == nil then
         return nil

--- a/lua/gitportal/git.lua
+++ b/lua/gitportal/git.lua
@@ -192,15 +192,6 @@ function M.checkout_branch_or_commit(branch_or_commit)
 end
 
 function M.get_git_url_for_current_file()
-    -- Creates a url for the current file in github. General formula follows...
-    --[[
-    Example url: https://github.com/trevorhauter/gitportal.nvim/blob/main/lua/gitportal/cli.lua#L1-L2
-    remote url: https://github.com/trevorhauter/gitportal.nvim
-    blob: blob
-    branch_or_commit: main | 7b6d66e0098678af63189b96f0d6f12e8ee961c3
-    file_path: lua/gitportal/cli.lua
-    Line highlights: #L1 | #L1-L2
-  --]]
     if M.can_open_current_file() == false then
         return nil
     end

--- a/lua/gitportal/git.lua
+++ b/lua/gitportal/git.lua
@@ -32,7 +32,7 @@ function M.get_origin_url()
     return cli.run_command("git config --get remote.origin.url")
 end
 
-function M.get_provider_from_map(origin_url)
+function M.get_provider_info_from_map(origin_url)
     if config.options.git_provider_map ~= nil then
         for url, contents in pairs(config.options.git_provider_map) do
             if string.find(origin_url, url, 0, true) then
@@ -40,6 +40,7 @@ function M.get_provider_from_map(origin_url)
             end
         end
     end
+    return nil
 end
 
 function M.determine_git_host()
@@ -51,7 +52,7 @@ function M.determine_git_host()
     -- See if the user has specified the provider for this repository
     local provider
     if config.options.git_provider_map ~= nil then
-        provider = M.get_provider_from_map(origin_url)
+        provider = M.get_provider_info_from_map(origin_url)
         if provider then
             if type(provider) == "string" then
                 return provider
@@ -162,7 +163,7 @@ end
 local function get_base_git_host_url()
     local base_git_host_url
     if config.options.git_provider_map ~= nil then
-        local provider_info = M.get_provider_from_map(M.get_origin_url())
+        local provider_info = M.get_provider_info_from_map(M.get_origin_url())
         if provider_info and type(provider_info) == "table" then
             base_git_host_url = provider_info.base_url
         end

--- a/lua/gitportal/git.lua
+++ b/lua/gitportal/git.lua
@@ -160,7 +160,7 @@ function M.parse_origin_url(origin_url)
     return origin_url
 end
 
-local function get_base_git_host_url()
+function M.get_base_git_host_url()
     local base_git_host_url
     if config.options.git_provider_map ~= nil then
         local provider_info = M.get_provider_info_from_map(M.get_origin_url())
@@ -214,7 +214,7 @@ function M.get_git_url_for_current_file()
         return nil
     end
 
-    local remote_url = get_base_git_host_url()
+    local remote_url = M.get_base_git_host_url()
     local branch_or_commit = M.get_branch_or_commit()
     local git_path = M.get_git_file_path()
     local git_host = M.determine_git_host()

--- a/lua/gitportal/git.lua
+++ b/lua/gitportal/git.lua
@@ -38,14 +38,23 @@ function M.determine_git_host()
         return nil
     end
 
+    -- See if the user has specified the provider for this repository
+    local provider
     if config.options.git_provider_map ~= nil then
-        for url, host in pairs(config.options.git_provider_map) do
+        for url, contents in pairs(config.options.git_provider_map) do
+            if type(contents) == "string" then
+                provider = contents
+            elseif type(contents) == "table" then
+                provider = contents.provider
+            end
             if string.find(origin_url, url, 0, true) then
-                return host
+                return provider
             end
         end
     end
 
+    -- No match was found in provider_map. So try to derive the git provider from
+    -- the origin URL
     for host, host_info in pairs(git_providers) do
         if string.find(origin_url, host_info.name, 0, true) then
             return host

--- a/lua/gitportal/git.lua
+++ b/lua/gitportal/git.lua
@@ -131,7 +131,7 @@ end
 
 function M.parse_origin_url(origin_url)
     -- remove any trailing spaces or line breaks from the end of the line
-    origin_url = origin_url:gsub("%s$", "")
+    origin_url = origin_url:gsub("%s+$", "")
     -- Trim any appending .git from the url, including new line
     origin_url = origin_url:gsub("%.git$", "")
 

--- a/lua/gitportal/git_providers.lua
+++ b/lua/gitportal/git_providers.lua
@@ -1,11 +1,4 @@
 -- CONFIGURATION FOR ALL SUPPORT GIT PROVIDERS
---
--- This follows the following format
--- github = {
---     name = github, -- host name
---     ssh_str = "git@github.com", -- beginning string that appears in SSH origin URL for host for (N/A if self hosted)
---     url = "https://github.com/", -- beginning string that appears in https origin URL for host (N/A if self hosted)
--- }
 
 local function standard_line_range_parser(url)
     local start_line, end_line = nil, nil

--- a/tests/test_git.lua
+++ b/tests/test_git.lua
@@ -133,7 +133,7 @@ function TestGit:test_determine_git_host()
     lu.assertEquals(git_host, self.current_git_host)
 end
 
-function TestGit:test_determine_git_host_provider_map()
+function TestGit:test_determine_git_host_provider_map_old()
     config.options.git_provider_map = {
         ["https://www.coolcompany.com"] = "github",
         ["https://merp.com/gitportal/gitlab-test.git"] = "gitlab",
@@ -142,7 +142,6 @@ function TestGit:test_determine_git_host_provider_map()
     self.current_git_host = "https://www.coolcompany.com/gitportal/test.git"
     local git_host = git.determine_git_host()
     lu.assertEquals(git_host, "github")
-    -- complete the rest of the tests for the 2 remaining entries in the git_provider_map
 
     self.current_git_host = "https://merp.com/gitportal/gitlab-test.git"
     git_host = git.determine_git_host()
@@ -151,6 +150,49 @@ function TestGit:test_determine_git_host_provider_map()
     self.current_git_host = "git@dev.COMPANY_NAME.com:random_word/random_word_2/REPO.git"
     git_host = git.determine_git_host()
     lu.assertEquals(git_host, "random")
+end
+
+function TestGit:test_determine_git_host_provider_map_new()
+    config.options.git_provider_map = {
+        ["https://www.coolcompany.com"] = { provider = "github" },
+        ["https://merp.com/gitportal/gitlab-test.git"] = { provider = "gitlab" },
+        ["git@dev.COMPANY_NAME.com:random_word/random_word_2/REPO.git"] = { provider = "random" },
+    }
+    self.current_git_host = "https://www.coolcompany.com/gitportal/test.git"
+    local git_host = git.determine_git_host()
+    lu.assertEquals(git_host, "github")
+
+    self.current_git_host = "https://merp.com/gitportal/gitlab-test.git"
+    git_host = git.determine_git_host()
+    lu.assertEquals(git_host, "gitlab")
+
+    self.current_git_host = "git@dev.COMPANY_NAME.com:random_word/random_word_2/REPO.git"
+    git_host = git.determine_git_host()
+    lu.assertEquals(git_host, "random")
+end
+
+function TestGit:test_get_provider_info_from_map()
+    config.options.git_provider_map = {
+        ["https://www.coolcompany.com"] = { provider = "github", base_url = nil },
+        ["https://merp.com/gitportal/gitlab-test.git"] = { provider = "merp", base_url = "https://merp.com" },
+    }
+    local origin_url
+    local provider_info
+
+    -- origin url does not match any items in the map
+    origin_url = "www.random.net"
+    provider_info = git.get_provider_info_from_map(origin_url)
+    lu.assertEquals(provider_info, nil)
+
+    origin_url = "https://www.coolcompany.com/gitportal/test.git"
+    provider_info = git.get_provider_info_from_map(origin_url)
+    lu.assertEquals(provider_info.provider, "github")
+    lu.assertEquals(provider_info.base_url, nil)
+
+    origin_url = "https://merp.com/gitportal/gitlab-test.git"
+    provider_info = git.get_provider_info_from_map(origin_url)
+    lu.assertEquals(provider_info.provider, "merp")
+    lu.assertEquals(provider_info.base_url, "https://merp.com")
 end
 
 -- ****

--- a/tests/test_git.lua
+++ b/tests/test_git.lua
@@ -221,7 +221,23 @@ function TestGit:test_parse_origin_url()
 
     for _, scenario in ipairs(scenario_map) do
         lu.assertEquals(git.parse_origin_url(scenario.origin_url), scenario.result)
+
+        self.current_git_host = scenario.origin_url
+        -- test the base git host url here too!
+        lu.assertEquals(git.get_base_git_host_url(), scenario.result)
     end
+end
+
+function TestGit:test_get_base_git_host_url_provider_map()
+    config.options.git_provider_map = {
+        ["https://www.coolcompany.com"] = { provider = "github", base_url = "random.org" },
+    }
+
+    self.current_git_host = "https://www.coolcompany.com"
+    lu.assertEquals(git.get_base_git_host_url(), "random.org")
+
+    self.current_git_host = "git@gitlab.com:gitportal/gitlab-test.git"
+    lu.assertEquals(git.get_base_git_host_url(), "https://gitlab.com/gitportal/gitlab-test")
 end
 
 -- ****

--- a/tests/test_git.lua
+++ b/tests/test_git.lua
@@ -195,6 +195,35 @@ function TestGit:test_get_provider_info_from_map()
     lu.assertEquals(provider_info.base_url, "https://merp.com")
 end
 
+function TestGit:test_parse_origin_url()
+    local scenario_map = {
+        {
+            origin_url = "https://www.github.com.git  ",
+            result = "https://www.github.com",
+        },
+        {
+            origin_url = "git@gitlab.com:gitportal/gitlab-test.git",
+            result = "https://gitlab.com/gitportal/gitlab-test",
+        },
+        {
+            origin_url = "git@ssh.merp.com.git ",
+            result = "https://merp.com",
+        },
+        {
+            origin_url = "ssh://localhost:6611/advanced-app",
+            result = "https://localhost:6611/advanced-app",
+        },
+        {
+            origin_url = "git@selfhost.com:advanced-app",
+            result = "https://selfhost.com/advanced-app",
+        },
+    }
+
+    for _, scenario in ipairs(scenario_map) do
+        lu.assertEquals(git.parse_origin_url(scenario.origin_url), scenario.result)
+    end
+end
+
 -- ****
 -- END TESTS
 -- ****

--- a/tests/test_git.lua
+++ b/tests/test_git.lua
@@ -23,7 +23,6 @@ function TestGit:setUp()
     self.commit = "64ad8be39a26d41c81a30513dc2b7f9816f7f7ae"
     self.active_branch_or_commit = nil
     self.current_git_host = nil
-    config.options.git_platform = nil
 
     -- ****
     -- Mock functions for tests
@@ -132,13 +131,6 @@ function TestGit:test_determine_git_host()
     self.current_git_host = git_providers.gitlab.name
     git_host = git.determine_git_host()
     lu.assertEquals(git_host, self.current_git_host)
-end
-
-function TestGit:test_determine_git_host_platform_config()
-    config.options.git_platform = "random"
-    self.current_git_host = "nonsense"
-    local git_host = git.determine_git_host()
-    lu.assertEquals(git_host, "random")
 end
 
 function TestGit:test_determine_git_host_provider_map()

--- a/tests/test_providers/test_github.lua
+++ b/tests/test_providers/test_github.lua
@@ -1,4 +1,5 @@
 local git_providers = require("gitportal.git_providers")
+local git_utils = require("gitportal.git")
 local lu = require("luaunit")
 
 local complete_url = "https://github.com/trevorhauter/gitportal.nvim/blob/main/lua/gitportal/cli.lua"
@@ -26,6 +27,10 @@ function TestGitHub:test_string_attributes()
     lu.assertEquals(provider.name, "github")
     lu.assertEquals(provider.ssh_str, "git@github.com")
     lu.assertEquals(provider.url, "https://github.com/")
+end
+
+function TestGitHub:test_origin_url_parsing()
+    lu.assertEquals(git_utils.parse_origin_url(provider.ssh_str), "https://github.com")
 end
 
 function TestGitHub:test_single_line_parsing()

--- a/tests/test_providers/test_gitlab.lua
+++ b/tests/test_providers/test_gitlab.lua
@@ -1,4 +1,5 @@
 local git_providers = require("gitportal.git_providers")
+local git_utils = require("gitportal.git")
 local lu = require("luaunit")
 
 local complete_url = "https://gitlab.com/gitportal/gitlab-test/-/blob/master/public/index.html"
@@ -26,6 +27,10 @@ function TestGitLab:test_string_attributes()
     lu.assertEquals(provider.name, "gitlab")
     lu.assertEquals(provider.ssh_str, "git@gitlab.com")
     lu.assertEquals(provider.url, "https://gitlab.com/")
+end
+
+function TestGitLab:test_origin_url_parsing()
+    lu.assertEquals(git_utils.parse_origin_url(provider.ssh_str), "https://gitlab.com")
 end
 
 function TestGitLab:test_single_line_parsing()

--- a/tests/test_url_utils.lua
+++ b/tests/test_url_utils.lua
@@ -186,19 +186,6 @@ function TestParseGitHostUrl:test_self_host_gitlab_url()
     test_githost_url(base_url, expected_result, gitlab_single_line_info, gitlab_line_range_info)
 end
 
-function TestParseGitHostUrl:test_self_host_gitlab_url_platform()
-    config.options.git_platform = "gitlab"
-    local base_url = "https://dev.company_name.com/random_word/random_word_2/REPO/-/blob/master/public/index.html"
-    local expected_result = {
-        repo = "REPO",
-        branch_or_commit = "master",
-        file_path = "public/index.html",
-        start_line = nil,
-        end_line = nil,
-    }
-    test_githost_url(base_url, expected_result, gitlab_single_line_info, gitlab_line_range_info)
-end
-
 function TestParseGitHostUrl:test_self_host_gitlab_url_provider_map()
     self.origin_url = "https://dev.company_name.com"
     config.options.git_provider_map = { ["https://dev.company_name.com"] = "gitlab" }
@@ -275,7 +262,6 @@ local onedev_single_line_info = { url = "?position=source-45.1-45.14-1", start_l
 local onedev_line_range_info = { url = "?position=source-50.1-55.14-1", start_line = 50, end_line = 55 }
 
 function TestParseGitHostUrl:test_self_host_onedev_url_https()
-    config.options.git_platform = nil
     self.origin_url = "http://localhost:6610/advanced-app"
     config.options.git_provider_map = { ["http://localhost:6610/advanced-app"] = "onedev" }
     local base_url =
@@ -293,7 +279,6 @@ end
 function TestParseGitHostUrl:test_self_host_onedev_url_https_random_commit()
     -- Onedev always has a commit in the url, oftentimes the user is on a branch.
     -- Onedev has an edge case built in that will recognize and account for this
-    config.options.git_platform = nil
     self.origin_url = "http://localhost:6610/advanced-app"
     config.options.git_provider_map = { ["http://localhost:6610/advanced-app"] = "onedev" }
     local base_url =
@@ -310,7 +295,6 @@ end
 
 function TestParseGitHostUrl:test_self_host_onedev_url_ssh()
     self.origin_url = "ssh://localhost:6610/advanced-app"
-    config.options.git_platform = nil
     config.options.git_provider_map = { ["ssh://localhost:6610/advanced-app"] = "onedev" }
     local base_url =
         "http://localhost:6610/advanced-app/~files/3130016177a84bf5e0f36c7c70ad434dca121d4b/components/main.jsx"


### PR DESCRIPTION
- [x] Remove deprecated configuration option `git_platform`
- [x] Add the option for `git_provider_map` to be a table with additional configuration options for git providers
- [x] Add tests for new functionality
- [x] Add tests for `parse_origin_url`
- [x] Add tests for `get_base_git_host_url` 
- [x] Update readme