### PR TITLE
Fix parsing of origin_url

### DIFF
--- a/lua/gitportal/git.lua
+++ b/lua/gitportal/git.lua
@@ -154,7 +154,7 @@ function M.parse_origin_url(origin_url)
             -- Otherwise, just convert the ssh to a URL like normal
             origin_url = origin_url:gsub("git@", "https://")
         end
-        origin_url = origin_url:gsub("%.com:", ".com/")
+        origin_url = origin_url:gsub("([%w%.%-]+%.[a-z]+):", "%1/")
     end
 
     return origin_url


### PR DESCRIPTION
This pattern was too permissive and could accidentally match domains that shouldn't be changed, or ones not ending in .com.