### PR TITLE
Add option to always use commit hash in url generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,9 @@ If you wish to keep these defaults, no configuration is required. To customize t
     -- Permalink generation | Include current line in URL regardless of current mode
     always_include_current_line = false, -- bool
 
+    -- Permalink generation | Always use the commit hash; otherwise use current branch/commit
+    always_use_commit_hash_in_url = false, -- bool
+
     -- Branch/commit handling when opening links in neovim
     switch_branch_or_commit_upon_ingestion = "always", -- "always" | "ask_first" | "never"
 

--- a/lua/gitportal/config.lua
+++ b/lua/gitportal/config.lua
@@ -5,6 +5,7 @@ local M = {}
 -- Default configuration
 local default = {
     always_include_current_line = false,
+    always_use_commit_hash_in_url = false,
     switch_branch_or_commit_upon_ingestion = "always", -- Can be "always", "ask_first", or "never"
     browser_command = nil, -- String of the command used on command line to open link in browser
     git_provider_map = nil, -- Map of urls to their git providers

--- a/lua/gitportal/git.lua
+++ b/lua/gitportal/git.lua
@@ -112,7 +112,7 @@ function M.get_branch_or_commit()
     local branch_or_commit = cli.run_command("git rev-parse --abbrev-ref HEAD")
     local revision_type = "branch"
 
-    if branch_or_commit == "HEAD\n" then
+    if branch_or_commit == "HEAD\n" or config.options.always_use_commit_hash_in_url == true then
         branch_or_commit = cli.run_command("git rev-parse HEAD")
         revision_type = "commit"
     end

--- a/tests/test_git.lua
+++ b/tests/test_git.lua
@@ -51,11 +51,18 @@ function TestGit:setUp()
             return "HEAD\n"
         end
 
-        if param == "git rev-parse --abbrev-ref HEAD" and self.active_branch_or_commit == self.branch then
+        if
+            param == "git rev-parse --abbrev-ref HEAD"
+            and self.active_branch_or_commit == self.branch
+            and config.options.always_use_commit_hash_in_url == false
+        then
             return self.branch
         end
 
-        if param == "git rev-parse HEAD" and self.active_branch_or_commit == self.commit then
+        if
+            param == "git rev-parse HEAD" and self.active_branch_or_commit == self.commit
+            or config.options.always_use_commit_hash_in_url == true
+        then
             return self.commit
         end
     end
@@ -111,7 +118,19 @@ function TestGit:test_get_branch_or_commit()
     lu.assertEquals(result.name, self.branch)
     lu.assertEquals(result.type, "branch")
 
+    config.options.always_use_commit_hash_in_url = true
+
+    result = git.get_branch_or_commit()
+
+    if result == nil then
+        error("git.get_branch_or_commit() returned nil")
+    end
+
+    lu.assertEquals(result.name, self.commit)
+    lu.assertEquals(result.type, "commit")
+
     self.active_branch_or_commit = self.commit
+    config.options.always_use_commit_hash_in_url = false
 
     result = git.get_branch_or_commit()
 


### PR DESCRIPTION
This is something I've wanted for a while. Commit hashes give you more accurate snapshots of time, as the code linked does not change as opposed to a branch. There is always better support for code previews for that reason here on GitHub, and I imagine that's true for other platforms as well.